### PR TITLE
Refactor to meet line length standard

### DIFF
--- a/src/main/java/org/jabref/logic/util/strings/StringSimilarity.java
+++ b/src/main/java/org/jabref/logic/util/strings/StringSimilarity.java
@@ -1,8 +1,8 @@
 package org.jabref.logic.util.strings;
 
-import java.util.Locale;
-
 import info.debatty.java.stringsimilarity.Levenshtein;
+
+import java.util.Locale;
 
 public class StringSimilarity {
     private final Levenshtein METRIC_DISTANCE = new Levenshtein();
@@ -22,6 +22,8 @@ public class StringSimilarity {
 
     public double editDistanceIgnoreCase(String a, String b) {
         // TODO: Locale is dependent on the language of the strings. English is a good denominator.
-        return METRIC_DISTANCE.distance(a.toLowerCase(Locale.ENGLISH), b.toLowerCase(Locale.ENGLISH));
+        a = a.toLowerCase(Locale.ENGLISH);
+        b = b.toLowerCase(Locale.ENGLISH);
+        return METRIC_DISTANCE.distance(a, b);
     }
 }

--- a/src/test/java/org/jabref/logic/util/strings/StringSimilarityTest.java
+++ b/src/test/java/org/jabref/logic/util/strings/StringSimilarityTest.java
@@ -1,0 +1,53 @@
+package org.jabref.logic.util.strings;
+
+import org.junit.Test;
+import org.junit.Before;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class StringSimilarityTest {
+
+    private StringSimilarity sut;
+
+    @Before
+    public void setup() {
+        sut = new StringSimilarity();
+    }
+
+    @Test
+    public void givenIdenticalStrings_whenIsSimilarMethod_thenReturnTrue() {
+        String a = "Hello";
+        String b = "Hello";
+        assertTrue(sut.isSimilar(a, b));
+    }
+
+    @Test
+    public void givenIdenticalStrings_whenEditDistanceIgnoreCaseMethod_thenReturnZero() {
+        String a = "A";
+        String b = "A";
+        assertEquals(0.0, sut.editDistanceIgnoreCase(a, b));
+    }
+
+    @Test
+    public void givenSlightlyDifferentStrings_whenEditDistanceIgnoreCaseMethod_thenReturnLevenshteinDistance() {
+        String a = "Abc";
+        String b = "Bbc";
+        assertEquals(1.0, sut.editDistanceIgnoreCase(a,b));
+    }
+
+    @Test
+    public void givenVeryDifferentStrings_whenEditDistanceIgnoreCaseMethod_thenReturnLevenshteinDistance() {
+        String a = "Fish";
+        String b = "Bears";
+        assertEquals(5.0, sut.editDistanceIgnoreCase(a,b));
+    }
+
+    @Test
+    public void givenDissimilarStrings_whenIsSimilarMethod_thenReturnFalse() {
+        String a = "Johnson";
+        String b = "Daghtsen";
+        System.out.println(sut.editDistanceIgnoreCase(a,b));
+        assertFalse(sut.isSimilar(a,b));
+    }
+
+}


### PR DESCRIPTION
Google coding standard for line length is 100 characters.  This fix breaks one long line of 103 characters down into 3 smaller lines.  No logic was changed.

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
