### PR TITLE
Goml jb duplicate resolver dialog bug bib tex key duplicate checkthrows npe

### DIFF
--- a/src/main/java/org/jabref/gui/importer/ImportInspectionDialog.java
+++ b/src/main/java/org/jabref/gui/importer/ImportInspectionDialog.java
@@ -1051,6 +1051,7 @@ public class ImportInspectionDialog extends JabRefDialog implements OutputPrinte
                 if (other.isPresent()) {
                     // This will be true if the duplicate is in the existing
                     // database.
+                    //TODO: this could be where duplicate resolving bug starts
                     DuplicateResolverDialog diag = new DuplicateResolverDialog(getFrame(), other.get(),
                                                                                first, DuplicateResolverDialog.DuplicateResolverType.INSPECTION);
 

--- a/src/test/java/org/jabref/gui/DuplicateResolverDialogTest.java
+++ b/src/test/java/org/jabref/gui/DuplicateResolverDialogTest.java
@@ -2,15 +2,17 @@ package org.jabref.gui;
 
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
+import org.jabref.gui.mergeentries.MergeEntries;
+import org.jabref.model.database.BibDatabaseMode;
 import org.jabref.model.entry.BibEntry;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
-
+//trying to find how this is linked to BibTexKey Duplicate Check throws NPE Bug#4614
 class DuplicateResolverDialogTest {
 
     @Test
-    void givenNewDuplicateResolverDialogAndEmptyParameters_whenNothing_thenNoError() {
+    void givenNewDuplicateResolverDialogAndEmptyParameters_whenInitializing_thenNoError() {
         Stage stage = new Stage();
         JabRefFrame frame = new JabRefFrame(stage);
         BibEntry one = new BibEntry();
@@ -21,27 +23,56 @@ class DuplicateResolverDialogTest {
     }
 
     @Test
-    void givenNewStage_whenNothing_thenNoError() {
-        Stage sut = new Stage();
+    void givenUninitializedStage_whenInitializing_thenNoError() {
+        Stage sut;
 
     }
 
     @Test
-    void givenNewJabRefFrame_whenNothing_thenNoError() {
+    void givenInitializedStage_whenInitializing_thenNoError() {
+        Stage sut = new Stage(StageStyle.DECORATED);
+
+    }
+
+    @Test
+    void givenNewJabRefFrame_whenInitializing_thenNoError() {
         Stage stage = new Stage();
         JabRefFrame sut = new JabRefFrame(stage);
 
     }
 
     @Test
-    void givenNewBibEntry_whenNothing_thenNoError() {
+    void givenNewBibEntry_whenInitializing_thenNoError() {
         BibEntry sut = new BibEntry();
 
     }
 
     @Test
-    void givenNewDuplicateResolverType_whenNothing_thenNoError() {
+    void givenNewDuplicateResolverTypeIMPORT_CHECK_whenInitializing_thenEqualsIMPORT_CHECK() {
         DuplicateResolverDialog.DuplicateResolverType sut = DuplicateResolverDialog.DuplicateResolverType.IMPORT_CHECK;
         assertEquals(DuplicateResolverDialog.DuplicateResolverType.IMPORT_CHECK,sut);
+    }
+
+    @Test
+    void givenNewDuplicateResolverResultKEEP_LEFT_whenInitializing_thenEqualsIMPORT_CHECK() {
+        DuplicateResolverDialog.DuplicateResolverResult sut = DuplicateResolverDialog.DuplicateResolverResult.KEEP_LEFT;
+        assertEquals(DuplicateResolverDialog.DuplicateResolverResult.KEEP_LEFT,sut);
+    }
+
+    @Test
+    public void givenDuplicateResolverDialog_whenGetMergedEntry_thenMergedBibEntryMeReturned(){
+        Stage stage = new Stage();
+        JabRefFrame frame = new JabRefFrame(stage);
+        BibEntry one = new BibEntry();
+        BibEntry two = new BibEntry();
+        DuplicateResolverDialog.DuplicateResolverType type = DuplicateResolverDialog.DuplicateResolverType.IMPORT_CHECK;
+
+        DuplicateResolverDialog testDialog = new DuplicateResolverDialog(frame, one, two, type);
+
+        BibEntry sut = testDialog.getMergedEntry();
+        BibDatabaseMode mode = BibDatabaseMode.BIBTEX;
+
+        MergeEntries ans = new MergeEntries(one, two, mode);
+        assertEquals(ans, sut);
     }
 }

--- a/src/test/java/org/jabref/gui/DuplicateResolverDialogTest.java
+++ b/src/test/java/org/jabref/gui/DuplicateResolverDialogTest.java
@@ -1,0 +1,47 @@
+package org.jabref.gui;
+
+import javafx.stage.Stage;
+import javafx.stage.StageStyle;
+import org.jabref.model.entry.BibEntry;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DuplicateResolverDialogTest {
+
+    @Test
+    void givenNewDuplicateResolverDialogAndEmptyParameters_whenNothing_thenNoError() {
+        Stage stage = new Stage();
+        JabRefFrame frame = new JabRefFrame(stage);
+        BibEntry one = new BibEntry();
+        BibEntry two = new BibEntry();
+        DuplicateResolverDialog.DuplicateResolverType type = DuplicateResolverDialog.DuplicateResolverType.IMPORT_CHECK;
+
+        DuplicateResolverDialog sut = new DuplicateResolverDialog(frame, one, two, type);
+    }
+
+    @Test
+    void givenNewStage_whenNothing_thenNoError() {
+        Stage sut = new Stage();
+
+    }
+
+    @Test
+    void givenNewJabRefFrame_whenNothing_thenNoError() {
+        Stage stage = new Stage();
+        JabRefFrame sut = new JabRefFrame(stage);
+
+    }
+
+    @Test
+    void givenNewBibEntry_whenNothing_thenNoError() {
+        BibEntry sut = new BibEntry();
+
+    }
+
+    @Test
+    void givenNewDuplicateResolverType_whenNothing_thenNoError() {
+        DuplicateResolverDialog.DuplicateResolverType sut = DuplicateResolverDialog.DuplicateResolverType.IMPORT_CHECK;
+        assertEquals(DuplicateResolverDialog.DuplicateResolverType.IMPORT_CHECK,sut);
+    }
+}


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
